### PR TITLE
New Patroni image based on Postgres 13 and Patroni 2.1

### DIFF
--- a/images/Dockerfile.patroni
+++ b/images/Dockerfile.patroni
@@ -1,4 +1,4 @@
-FROM postgres:11
+FROM postgres:13
 MAINTAINER Josh Berkus <josh@berkus.org>
 
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/images/patroni/patroni_k8s.yaml
+++ b/images/patroni/patroni_k8s.yaml
@@ -1,0 +1,213 @@
+## optional, a load-balancing service
+## for read-only connections and direct
+## connections to a specific backend
+apiVersion: v1
+kind: Service
+metadata:
+  name: patronidemo-ro
+spec:
+  ports:
+  - port: 5432
+    name: psql
+  - port: 8008
+    name: patronictl
+  clusterIP: None
+  selector:
+    application: patroni
+    cluster-name: patronidemo
+
+---
+## endpoint, this is the master connection endpoint
+# also used as a lock for master election contests
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: &cluster_name patronidemo
+  labels:
+    application: patroni
+    cluster-name: *cluster_name
+subsets: []
+
+---
+## service for the master endpoint
+apiVersion: v1
+kind: Service
+metadata:
+  name: &cluster_name patronidemo
+  labels:
+    application: patroni
+    cluster-name: *cluster_name
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+
+---
+## the statefulset, this is the actual database nodes
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: &cluster_name patronidemo
+  labels:
+    application: patroni
+    cluster-name: *cluster_name
+spec:
+  replicas: 3
+# change to *clustername if not using the load-balancing service
+  serviceName: patronidemo
+  selector:
+    matchLabels:
+      application: patroni
+      cluster-name: *cluster_name
+  template:
+    metadata:
+      labels:
+        application: patroni
+        cluster-name: *cluster_name
+    spec:
+      serviceAccountName: patronidemo
+      containers:
+      - name: *cluster_name
+        image: jberkus/patroni-simple:v13
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8008
+          protocol: TCP
+        - containerPort: 5432
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /home/postgres/pgdata
+          name: pgdata
+        env:
+        - name: PATRONI_KUBERNETES_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: PATRONI_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PATRONI_KUBERNETES_LABELS
+          value: '{application: patroni, cluster-name: patronidemo}'
+        - name: PATRONI_SUPERUSER_USERNAME
+          value: postgres
+        - name: PATRONI_SUPERUSER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: *cluster_name
+              key: superuser-password
+        - name: PATRONI_REPLICATION_USERNAME
+          value: standby
+        - name: PATRONI_REPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: *cluster_name
+              key: replication-password
+        - name: PATRONI_SCOPE
+          value: *cluster_name
+        - name: PATRONI_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: PATRONI_POSTGRESQL_DATA_DIR
+          value: /home/postgres/pgdata/pgroot/data
+        - name: PATRONI_POSTGRESQL_PGPASS
+          value: /tmp/pgpass
+        - name: PATRONI_POSTGRESQL_LISTEN
+          value: '0.0.0.0:5432'
+        - name: PATRONI_RESTAPI_LISTEN
+          value: '0.0.0.0:8008'
+      terminationGracePeriodSeconds: 0
+  volumeClaimTemplates:
+  - metadata:
+      annotations:
+       volume.alpha.kubernetes.io/storage-class: anything
+      name: pgdata
+    spec:
+     accessModes:
+     - ReadWriteOnce
+     resources:
+       requests:
+         storage: 1Gi
+
+---
+# passwords for the patroni database
+# if you had more users + passwords, you'd add them
+# here
+apiVersion: v1
+kind: Secret
+metadata:
+  name: &cluster_name patronidemo
+  labels:
+    application: patroni
+    cluster-name: *cluster_name
+type: Opaque
+data:
+  superuser-password: emFsYW5kbw==
+  replication-password: cmVwLXBhc3M=
+
+---
+## the rest is a serviceaccount and RBAC
+# for permissions and access control for patroni
+# this is required for leader elections to work properly
+# and requires you to have admin rights on the
+# kubernetes cluster
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patronidemo
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: patronidemo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - patch
+  - update
+  # the following three privileges are necessary only when using endpoints
+  # and need to be removed for Openshift
+  - create
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: patronidemo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: patronidemo
+subjects:
+- kind: ServiceAccount
+  name: patronidemo


### PR DESCRIPTION
This updates Dockerfile.patroni and all supporting files for current Postgres and Patroni.

It incorporates changes from the patroni-patch, so those files are no longer necessary (but not deleted in this PR).

Tested using Minikube.